### PR TITLE
UI: amélioration du bloc d'infos générales selon la maquette Figma

### DIFF
--- a/src/components/blocInfos/BlocInfosGenerales.tsx
+++ b/src/components/blocInfos/BlocInfosGenerales.tsx
@@ -13,27 +13,29 @@ const GeneralInfoBlock = () => {
     <Flex
       direction={{ base: 'column', md: 'row' }}
       gap={6}
-      p={4}
-      align="stretch"
+      p={6} 
+      bg="#F4F6FA" 
+      borderRadius="xl"
     >
+  
       <Flex
         direction="column"
         w={{ base: '100%', md: '280px' }}
-        h="100%"
-        bg="#FCFCFF"
-        borderRadius="lg"
-        p={4}
+        minW="280px"
+        bg="white"
+        borderRadius="xl"
+        p={6}
+        boxShadow="lg"
       >
-        <Text fontWeight="semibold" mb={3}>
+        <Text fontWeight="semibold" mb={4} whiteSpace="nowrap">
           Informations général du dossier
         </Text>
 
         <Box
-          bg="white"
+          bg="#FCFCFF"
           flex="1"
           p={4}
           borderRadius="xl"
-          boxShadow="md"
           display="flex"
           alignItems="center"
           justifyContent="center"
@@ -41,25 +43,21 @@ const GeneralInfoBlock = () => {
           <Icon as={FaRegClipboard} boxSize={150} color="gray.600" />
         </Box>
       </Flex>
+
+   
       <Flex
         direction="column"
         flex="1"
-        h="100%"
-        bg="#FCFCFF"
-        borderRadius="lg"
-        p={4}
+        bg="white"
+        borderRadius="xl"
+        p={6}
+        boxShadow="lg"
       >
-        <Text fontWeight="semibold" mb={3}>
+        <Text fontWeight="semibold" mb={4}>
           Infos
         </Text>
 
-        <Box
-          bg="white"
-          flex="1"
-          p={8}
-          borderRadius="xl"
-          boxShadow="md"
-        >
+        <Box>
           <Grid templateColumns={{ base: '1fr', md: 'repeat(5, 1fr)' }} gap={6}>
             <GridItem>
               <Text fontWeight="semibold">Référence du dossier</Text>
@@ -100,7 +98,7 @@ const GeneralInfoBlock = () => {
           </Grid>
         </Box>
       </Flex>
-    </Flex> 
+    </Flex>
   );
 };
 


### PR DESCRIPTION
Cette pull request améliore la section "Informations général du dossier" conformément à la maquette Figma.

✔️ Aligne le titre sur une seule ligne
✔️ Ajout des ombres (box-shadow) pour chaque carte
✔️ Ajout de padding entre le fond (#FCFCFF) et les cartes internes
✔️ Structure propre et responsive avec Chakra UI
@Abdi714 @Diagaraf8 